### PR TITLE
Add Makefile to assist with install; update README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 resource
 .vscode
+*.docset

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,38 @@
+##
+##  usage:
+##    $ make install
+##
+
+MANPAGES = /usr/share/man
+DOCSETSDIR = $(HOME)/.local/share/Zeal/Zeal/docsets
+DOCSETNAME = Linux Man Pages
+# the supplied DOCSETNAME, with spaces replaced by underscores
+DOCSETNAME_ = $(subst $(null) $(null),_,$(DOCSETNAME))
+# workaround to allow subst'ing a space, since it normally trims whitespace
+null =
+# if not supplied, mandocset.py defaults to first word of DOCSETNAME_, split on underscores
+#SHORTCUT = man
+ICON = etc/tux.png
+ICON2X = $(ICON:.png=@2x.png)
+MAYBEDO = $(if $(DRYRUN),echo)
+
+
+docset: $(DOCSETNAME_).docset/Contents/Info.plist
+
+install: $(DOCSETSDIR)/$(DOCSETNAME_).docset/Contents/Info.plist
+
+clean:
+	$(MAYBEDO) rm -rf $(DOCSETNAME_).docset
+
+reallyclean: clean
+	$(MAYBEDO) rm -rf $(DOCSETSDIR)/$(DOCSETNAME_).docset
+
+$(DOCSETNAME_).docset/Contents/Info.plist:
+	$(MAYBEDO) python3 mandocset.py -o $(DOCSETNAME_) -i $(ICON) -I $(ICON2X) -p $(MANPAGES)
+ifneq ($(SHORTCUT),)
+	$(MAYBEDO) sed -i "/DocSetPlatformFamily/{N;s^<string>.*</string>^<string>$(SHORTCUT)</string>^;}" $@
+endif
+
+# use 'cp -r' here if you don't have 'rsync' installed
+$(DOCSETSDIR)/$(DOCSETNAME_).docset/Contents/Info.plist: $(DOCSETNAME_).docset/Contents/Info.plist
+	$(MAYBEDO) rsync -av --delete $(DOCSETNAME_).docset $(DOCSETSDIR)

--- a/README.md
+++ b/README.md
@@ -1,18 +1,55 @@
 # mandocset
 
-This is python script (mandocset.py) that generates Dash docset from man pages. It takes folders with man pages as it's arguments. Then in each folder it finds all folders, containing digit in their name, runs `man2html -r` for each file inside them.
+This is Python script (`mandocset.py`) that generates a Dash docset from man pages. It takes folders with man pages as its arguments. Then in each folder it finds all folders containing digit in their name, and runs `man2html -r` for each file inside them.
 
-You can even generate docset of all manpages on your system (script supports mans compressed with gzip or bzip2), usually they are located at `/usr/share/man`.
+By default the script uses the `man2html` utility, which should be available from your distro's package manager. If you prefer [Pandoc][1], add `-e "pandoc -f man -t html"` to the command line.
 
-By default script uses man2html utility. If you prefer pandoc just use `-e "pandoc -f man -t html"`.
+## How to run
 
-### Some links to man pages
-* [manpages-posix](https://launchpad.net/ubuntu/+source/manpages-posix)
-* linux man pages' [git](https://www.kernel.org/doc/man-pages/)
+```bash
+python3 mandocset.py -o Linux_Man_Pages -p resource/man-pages-4.09/ resource/man-pages-posix-2013-a/ -i etc/tux.png -I etc/tux@2x.png
+```
 
-How to run: `python3 mandocset.py -o Linux_Man_Pages -p resourse/man-pages-4.09/ resourse/man-pages-posix-2013-a/ -i etc/tux.png -I etc/tux@2x.png`. You may also view help: `python3 mandocset.py -h`.
+Then copy or move the generated `Linux_Man_Pages.docset` to `~/.local/share/Zeal/Zeal/docsets` or `%APPDATA%\Local\Zeal\Zeal\docsets` on Windows.
 
-### Looking for linux manpages docset?
-1. Download `etc/Linux.docset.zip` from this repo
-2. Extract it to Linux.docset folder
-3. Move this folder to Zeal docsets (`C:\Users\%username%\AppData\Local\Zeal\Zeal\docsets` or `~/.local/share/Zeal/Zeal/docsets/`)
+You may also view help: `python3 mandocset.py -h`.
+
+### Looking for a pre-built Linux manpages docset?
+
+1. Download [`etc/Linux.docset.zip`](/blob/master/etc/Linux.docset.zip) from this repo
+2. Extract it to `Linux.docset` folder
+3. Move this folder to `%APPDATA%\Local\Zeal\Zeal\docsets` on Windows or `~/.local/share/Zeal/Zeal/docsets/` on Linux
+
+### Generating a docset from your system's installed manpages
+
+You can generate a docset of all manpages on your system (the script supports manpages compressed with gzip or bzip2). Usually these are located at `/usr/share/man`.
+
+On a reasonably well-equipped Linux system, the Makefile can do this for you:
+
+```bash
+cd ~/path/where/you/cloned/Yanpas/mandocset
+make docset
+
+# if the above works OK
+make install
+
+# print what would happen, but don't actually do it
+make install DRYRUN=1
+
+# remove previously-installed docsets
+make reallyclean
+
+# specify custom docset name and search shortcut (or just modify the Makefile)
+make install DOCSETNAME='Linux manpages' SHORTCUT=man
+```
+
+Look inside [the Makefile](Makefile) for other configurable settings.
+
+## Some links to man pages
+
+* [manpages-posix][2]
+* Linux man pages' [Git repository][3]
+
+[1]: https://pandoc.org
+[2]: https://launchpad.net/ubuntu/+source/manpages-posix
+[3]: https://www.kernel.org/doc/man-pages

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mandocset
 
-This is Python script (`mandocset.py`) that generates a Dash docset from man pages. It takes folders with man pages as its arguments. Then in each folder it finds all folders containing digit in their name, and runs `man2html -r` for each file inside them.
+This is a Python script ([`mandocset.py`](mandocset.py)) that generates a Dash docset from man pages. It takes folders with man pages as its arguments. Then in each folder it finds all folders containing digit in their name, and runs `man2html -r` for each file inside them.
 
 By default the script uses the `man2html` utility, which should be available from your distro's package manager. If you prefer [Pandoc][1], add `-e "pandoc -f man -t html"` to the command line.
 
@@ -24,11 +24,11 @@ You may also view help: `python3 mandocset.py -h`.
 
 You can generate a docset of all manpages on your system (the script supports manpages compressed with gzip or bzip2). Usually these are located at `/usr/share/man`.
 
-On a reasonably well-equipped Linux system, the Makefile can do this for you:
+On a reasonably well-equipped Linux system, the [included Makefile](Makefile) can do this for you:
 
 ```bash
 cd ~/path/where/you/cloned/Yanpas/mandocset
-make docset
+make  # or 'make docset'
 
 # if the above works OK
 make install
@@ -36,7 +36,7 @@ make install
 # print what would happen, but don't actually do it
 make install DRYRUN=1
 
-# remove previously-installed docsets
+# remove the previously-built docset
 make reallyclean
 
 # specify custom docset name and search shortcut (or just modify the Makefile)


### PR DESCRIPTION
Thanks for making this script to help with getting man pages into Zeal. It works great!

This PR is based on [this comment](https://github.com/zealdocs/zeal/issues/115#issuecomment-1703930999) in the Zealdocs/zeal repository.

I've added a Makefile to assist with (re)installation of a docset built from `/usr/share/man`, and updated the README a bit.

I'll understand completely if you close this without merging it, and no hard feelings. The current README is perfectly adequate for knowledgeable Linux users, and the Makefile won't help Windows users one bit (unless they're using WSL).